### PR TITLE
use default case in Request::defineMethod

### DIFF
--- a/core/Request.class.php
+++ b/core/Request.class.php
@@ -262,6 +262,8 @@ class Request
  			case 'PATCH':
  				$method = self::HTTP_PATCH;
  				break;
+            default:
+                $method = $methodAsString;
  		}
  		return $method;
  	}


### PR DESCRIPTION
i found a lot of such notices in the log: 
```
{
    "level": "proxy_fcgi:error",
    "pid": "24787:tid 140692986652416",
    "client": "132.232.200.142:40144",
    "message": "AH01071: Got error 'PHP message: PHP Notice:  Undefined variable: method in /var/www/html/tao/vendor/clearfw/clearfw/core/Request.class.php on line 266\\nPHP message: PHP Notice:  Undefined variable: method in /var/www/html/tao/vendor/clearfw/clearfw/core/Request.class.php on line 266\\n'",
    "instance_id": "i-029f2b5596a987341",
    "stack": "usact02dep",
    "host_type": "taocloud/ws/delivery"
}
```