### PR TITLE
chore: change severity level for unable to resolve errors

### DIFF
--- a/core/ResolverException.class.php
+++ b/core/ResolverException.class.php
@@ -32,5 +32,10 @@ class ResolverException extends Exception
 	{
 		parent::__construct($message);
 	}
+
+    public function getSeverity()
+    {
+        return common_Logger::INFO_LEVEL;
+    }
 }
 ?>


### PR DESCRIPTION
This PR changes the severity level for 'Unable to resolve...' errors in logs from 'error' to 'info'